### PR TITLE
Multibyte characters break layout

### DIFF
--- a/lua/startup/init.lua
+++ b/lua/startup/init.lua
@@ -319,14 +319,14 @@ function startup.mapping_names(mappings)
         for _, mapping in pairs(mappings) do
             if settings.options.mapping_keys then
                 local space = utils.spaces(
-                    length - #parse_mapping(mapping[3]) - #mapping[1]
+                    length - #parse_mapping(mapping[3]) - vim.fn.strdisplaywidth(mapping[1])
                 )
                 table.insert(
                     mapnames,
                     mapping[1] .. space .. parse_mapping(mapping[3])
                 )
             else
-                local space = utils.spaces(length - #mapping[1])
+                local space = utils.spaces(length - vim.fn.strdisplaywidth(mapping[1]))
                 table.insert(mapnames, mapping[1] .. space)
             end
         end


### PR DESCRIPTION
The following settings will break the layout as in the next image.

```lua
start_menu = {
  align = 'center',
  type = 'mapping',
  highlight = 'String',
  content = {
    { 'abc', 'quit', 'a' },
    { 'おはよう', 'quit', 'b' },
    { '123456789', 'quit', 'a' },
  },
},
```

![chry-temp-20240808232113](https://github.com/user-attachments/assets/7fe02442-a5ed-45d1-9820-327be68e6ce4)

This commit fixes this issue as shown in the following image.

![chry-temp-20240808232221](https://github.com/user-attachments/assets/74299d36-fc25-4b38-90ab-2ef3ad6115ce)
